### PR TITLE
Add argument redirect (optional) to is_active_feature

### DIFF
--- a/flask_featureflags/__init__.py
+++ b/flask_featureflags/__init__.py
@@ -17,7 +17,8 @@ See the License for the specific language governing permissions and
 from functools import wraps
 import logging
 
-from flask import abort, current_app, redirect, url_for
+from flask import abort, current_app, url_for
+from flask import redirect as _redirect
 
 __version__ = u'0.4dev'
 
@@ -143,7 +144,7 @@ def is_active(feature):
     return False
 
 
-def is_active_feature(feature, redirect_to=None, redirect_url_for=None):
+def is_active_feature(feature, redirect_to=None, redirect=None):
   """
   Decorator for Flask views. If a feature is off, it can either return a 404 or redirect to a URL if you'd rather.
   """
@@ -153,12 +154,12 @@ def is_active_feature(feature, redirect_to=None, redirect_url_for=None):
 
       if not is_active(feature):
         url = redirect_to
-        if redirect_url_for:
-          url = url_for(redirect_url_for)
+        if redirect:
+          url = url_for(redirect)
 
         if url:
           log.debug(u'Feature {feature} is off, redirecting to {url}'.format(feature=feature, url=url))
-          return redirect(url, code=302)
+          return _redirect(url, code=302)
         else:
           log.debug(u'Feature {feature} is off, aborting request'.format(feature=feature))
           abort(404)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -38,26 +38,21 @@ def redirect_destination():
   return FEATURE_IS_ON
 
 
-@app.route(u"/null_url_for")
-def redirect_destination_url_for():
-  return FEATURE_IS_ON
-
-
 @app.route(u"/decorator")
 @feature_flags.is_active_feature(FEATURE_NAME)
 def feature_decorator():
   return FEATURE_IS_ON
 
 
-@app.route(u"/redirect")
+@app.route(u"/redirect_to")
 @feature_flags.is_active_feature(FEATURE_NAME, redirect_to='/null')
-def redirect_with_decorator():
+def redirect_to_with_decorator():
   return FEATURE_IS_ON
 
 
-@app.route(u"/redirect_url_for")
-@feature_flags.is_active_feature(FEATURE_NAME, redirect_url_for='redirect_destination_url_for')
-def redirect_url_for_with_decorator():
+@app.route(u"/redirect")
+@feature_flags.is_active_feature(FEATURE_NAME, redirect='redirect_destination')
+def redirect_with_decorator():
   return FEATURE_IS_ON
 
 

--- a/tests/test_core_function.py
+++ b/tests/test_core_function.py
@@ -46,6 +46,17 @@ class TestFeatureFlagCoreFunctionality(unittest.TestCase):
       assert response.status_code == 404, u'Unexpected status code %s' % response.status_code
       assert FEATURE_IS_ON not in response.data.decode(u'utf-8')
 
+  def test_decorator_redirects_to_url_if_redirect_to_is_set_and_feature_is_off(self):
+      with self.app.test_request_context('/'):
+        url = url_for('redirect_to_with_decorator')
+
+        app.config[FLAG_CONFIG][FEATURE_NAME] = False
+
+        response = self.test_client.get(url)
+        assert response.status_code == 302, u'Unexpected status code %s' % response.status_code
+        assert response.location == url_for('redirect_destination', _external=True), \
+            u'Expected redirect to %s, got %s => ' % (url_for('redirect_destination'), response.location)
+
   def test_decorator_redirects_to_url_if_redirect_is_set_and_feature_is_off(self):
       with self.app.test_request_context('/'):
         url = url_for('redirect_with_decorator')
@@ -56,17 +67,6 @@ class TestFeatureFlagCoreFunctionality(unittest.TestCase):
         assert response.status_code == 302, u'Unexpected status code %s' % response.status_code
         assert response.location == url_for('redirect_destination', _external=True), \
             u'Expected redirect to %s, got %s => ' % (url_for('redirect_destination'), response.location)
-
-  def test_decorator_redirects_to_url_if_redirect_url_for_is_set_and_feature_is_off(self):
-      with self.app.test_request_context('/'):
-        url = url_for('redirect_url_for_with_decorator')
-
-        app.config[FLAG_CONFIG][FEATURE_NAME] = False
-
-        response = self.test_client.get(url)
-        assert response.status_code == 302, u'Unexpected status code %s' % response.status_code
-        assert response.location == url_for('redirect_destination_url_for', _external=True), \
-            u'Expected redirect to %s, got %s => ' % (url_for('redirect_destination_url_for'), response.location)
 
   def test_view_based_feature_flag_returns_new_code_if_flag_is_on(self):
     with self.app.test_request_context('/'):


### PR DESCRIPTION
It's not possible to use `url_for()` in the decorator call if the app context is not build yet. Therefore this patch adds a new optional argument named `redirect` to `is_active_feature`. It's the same as `redirect_to` but it triggers `url_for()` right before the redirect.
