### PR TITLE
add flask_featureflags.contrib sub package in install script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,12 @@ setup(
   test_suite="tests",
   platforms='any',
   include_package_data=True,
-  packages=['flask_featureflags'],
+  packages=[
+    'flask_featureflags',
+    'flask_featureflags.contrib',
+    'flask_featureflags.contrib.inline',
+    'flask_featureflags.contrib.sqlalchemy',
+  ],
   install_requires=[
     'Flask',
     ],


### PR DESCRIPTION
This changeset fixes the installed packages. Previously, `flask_featureflags.contrib` sub packages (including `inline` and `sqlalchemy`) were not installed through `pip install flask-featureflags`.