### PR TITLE
consistent version in __init__.py and setup.py

### DIFF
--- a/flask_featureflags/__init__.py
+++ b/flask_featureflags/__init__.py
@@ -21,7 +21,7 @@ from flask import abort, current_app, url_for
 from flask import redirect as _redirect
 from flask.signals import Namespace
 
-__version__ = u'0.4dev'
+__version__ = '0.7-dev'
 
 log = logging.getLogger(u'flask-featureflags')
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
+import codecs
 import os
+import re
 from setuptools import setup
 from sys import argv
 
@@ -17,9 +19,21 @@ if "develop" in argv:
   install_requires.append('Sphinx')
   install_requires.append('Sphinx-PyPI-upload')
 
+
+def find_version(*file_paths):
+  here = os.path.abspath(os.path.dirname(__file__))
+  with codecs.open(os.path.join(here, *file_paths), 'r') as f:
+    version_file = f.read()
+  version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                            version_file, re.M)
+  if version_match:
+    return version_match.group(1)
+  raise RuntimeError('Unable to find version string.')
+
+
 setup(
   name='Flask-FeatureFlags',
-  version='0.7-dev',
+  version=find_version('flask_featureflags', '__init__.py'),
   url='https://github.com/trustrachel/Flask-FeatureFlags',
   license='Apache',
   author='Rachel Sanders',


### PR DESCRIPTION
Previously, `flask_featureflags.__version__` is set to `0.4dev` while `setup.py` is set to `0.7-dev`.
This changeset ensures consistent version found in `flask_featureflags.__version__` and `setup.py`.

You can check the version in Python shell:

```python
>>> import flask_featureflags
>>> print(flask_featureflags.__version__)
0.7-dev
```

and using `pip freeze`:

```
$ pip freeze | grep FeatureFlags
Flask-FeatureFlags==0.7.dev0
```