### PR TITLE
use setuptools.find_packages to discover packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import codecs
 import os
 import re
 from setuptools import setup
+from setuptools import find_packages
 from sys import argv
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -46,12 +47,7 @@ setup(
   test_suite="tests",
   platforms='any',
   include_package_data=True,
-  packages=[
-    'flask_featureflags',
-    'flask_featureflags.contrib',
-    'flask_featureflags.contrib.inline',
-    'flask_featureflags.contrib.sqlalchemy',
-  ],
+  packages=find_packages(exclude=["tests*"]),
   install_requires=[
     'Flask',
     ],


### PR DESCRIPTION
This changeset introduces `setuptools.find_packages` to discover and install packages (`tests` directory will be excluded).
