### PR TITLE
Adding route definition to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ If you want to protect an entire view:
     from flask import Flask
     import flask_featureflags as feature
 
+    @app.route('/new/url')
     @feature.is_active_feature('unfinished_feature', redirect_to='/old/url')
     def index():
       # unfinished view code here


### PR DESCRIPTION
This tripped me up a bit, so thought explicitly stating the order of decorators could help.  

This works (404s):

```
@app.route('/feature-flag-test-route')
@is_active_feature('test_route')
def feature_flag_test_route():
    return 'on!'
```

This does not (returns 200, displays 'on!')

```
@is_active_feature('test_route')
@app.route('/feature-flag-test-route')
def feature_flag_test_route():
    return 'on!'
```
