### PR TITLE
Fix imports to remove warning per Flask recommendation.

### DIFF
--- a/flask_featureflags/__init__.py
+++ b/flask_featureflags/__init__.py
@@ -21,7 +21,7 @@ from flask import abort, current_app, url_for
 from flask import redirect as _redirect
 from flask.signals import Namespace
 
-__version__ = '0.7-dev'
+__version__ = '1.0'
 
 log = logging.getLogger(u'flask-featureflags')
 

--- a/flask_featureflags/contrib/inline/__init__.py
+++ b/flask_featureflags/contrib/inline/__init__.py
@@ -1,7 +1,7 @@
 from flask import current_app
-from flask.ext.featureflags import FEATURE_FLAGS_CONFIG
-from flask.ext.featureflags import NoFeatureFlagFound
-from flask.ext.featureflags import log
+from flask_featureflags import FEATURE_FLAGS_CONFIG
+from flask_featureflags import NoFeatureFlagFound
+from flask_featureflags import log
 
 
 class InlineFeatureFlag(object):

--- a/flask_featureflags/contrib/sqlalchemy/__init__.py
+++ b/flask_featureflags/contrib/sqlalchemy/__init__.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Integer, Boolean, String
 from sqlalchemy.orm.exc import NoResultFound
 from flask import current_app
-from flask.ext.featureflags import NoFeatureFlagFound, log
+from flask_featureflags import NoFeatureFlagFound, log
 
 
 class SQLAlchemyFeatureFlags(object):


### PR DESCRIPTION
Flask no longer recommend using the "flask.ext." import style; this change eliminates the warning currently generated by flask when using this extension.

http://flask.pocoo.org/docs/0.12/extensiondev/#extension-import-transition

(The 0.12 docs are somewhat contradictory on this, but the confusing text seems to have been removed in the latest dev docs.)