### PR TITLE
Update __init__.py to fix ExtDeprecationWarning

### DIFF
--- a/flask_featureflags/contrib/sqlalchemy/__init__.py
+++ b/flask_featureflags/contrib/sqlalchemy/__init__.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Integer, Boolean, String
 from sqlalchemy.orm.exc import NoResultFound
 from flask import current_app
-from flask.ext.featureflags import NoFeatureFlagFound, log
+from flask_featureflags import NoFeatureFlagFound, log
 
 
 class SQLAlchemyFeatureFlags(object):


### PR DESCRIPTION
This is the fix the following warning which happens whenever the module is loaded:
ExtDeprecationWarning: Importing flask.ext.featureflags is deprecated, use flask_featureflags instead.
  from flask.ext.featureflags import NoFeatureFlagFound, log